### PR TITLE
Groups' width of 1

### DIFF
--- a/s_package/poss_groups.py
+++ b/s_package/poss_groups.py
@@ -6,7 +6,7 @@ def f_p_groups(rang,min=8,max=19): #Function for possible groups
         possible_ammounts_groups.append(x)
 
     for num_groups in possible_ammounts_groups: 
-        if (rang % num_groups) == 0:
+        if (rang % num_groups) == 0 and (rang/num_groups) != 1:
             groups_width = rang / num_groups 
             results.append((groups_width, num_groups))
         else:


### PR DESCRIPTION
# Issue of groups' width one. #10 
Now the option of choosing a groups' width of one is removed. This is because it would be redundant when the regular frequency is already calculated.